### PR TITLE
Add short output format to kubectl version command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -87,7 +87,7 @@ func NewCmdVersion(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cob
 		},
 	}
 	cmd.Flags().BoolVar(&o.ClientOnly, "client", o.ClientOnly, "If true, shows client version only (no server required).")
-	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml' or 'json'.")
+	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml', 'json', or 'short'.")
 	return cmd
 }
 
@@ -117,8 +117,8 @@ func (o *Options) Validate() error {
 		return errors.New(fmt.Sprintf("extra arguments: %v", o.args))
 	}
 
-	if o.Output != "" && o.Output != "yaml" && o.Output != "json" {
-		return errors.New(`--output must be 'yaml' or 'json'`)
+	if o.Output != "" && o.Output != "yaml" && o.Output != "json" && o.Output != "short" {
+		return errors.New(`--output must be 'yaml', 'json', or 'short'`)
 	}
 
 	return nil
@@ -146,6 +146,11 @@ func (o *Options) Run() error {
 		fmt.Fprintf(o.Out, "Kustomize Version: %s\n", versionInfo.KustomizeVersion)
 		if versionInfo.ServerVersion != nil {
 			fmt.Fprintf(o.Out, "Server Version: %s\n", versionInfo.ServerVersion.GitVersion)
+		}
+	case "short":
+		fmt.Fprintf(o.Out, "%s\n", versionInfo.ClientVersion.GitVersion)
+		if versionInfo.ServerVersion != nil {
+			fmt.Fprintf(o.Out, "%s\n", versionInfo.ServerVersion.GitVersion)
 		}
 	case "yaml":
 		marshalled, err := yaml.Marshal(&versionInfo)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
@@ -54,3 +54,37 @@ func TestNewCmdVersionClientVersion(t *testing.T) {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
+
+func TestNewCmdVersionShortOutput(t *testing.T) {
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	o := NewOptions(streams)
+	o.ClientOnly = true
+	o.Output = "short"
+
+	cmd := NewCmdVersion(tf, streams)
+	cmd.Flags().Bool("warnings-as-errors", false, "")
+
+	if err := o.Complete(tf, cmd, nil); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if err := o.Validate(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if err := o.Run(); err != nil {
+		t.Errorf("Cannot execute version command: %v", err)
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 1 {
+		t.Errorf("Expected 1 line of output for client-only short format, got %d: %s", len(lines), output)
+	}
+	if !strings.HasPrefix(lines[0], "v") {
+		t.Errorf("Expected version string to start with 'v', got: %s", lines[0])
+	}
+	if strings.Contains(output, "Client Version:") || strings.Contains(output, "Server Version:") {
+		t.Errorf("Short output should not contain labels, got: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a new 'short' output format option to the `kubectl version` command
- The short format displays only the version numbers without labels
- This is useful for scripting scenarios where clean version output is needed

## Changes
- Updated version.go to support 'short' as a valid output format
- Modified validation logic to accept 'short' in addition to 'yaml' and 'json'
- Added comprehensive test coverage for the new short output format
- Updated help text to document the new option

## Test plan
- [x] Added unit test `TestNewCmdVersionShortOutput` to verify short format behavior
- [x] Test validates that output contains only version numbers without labels
- [x] Test verifies correct number of output lines for client-only mode
- [ ] Manual testing with actual kubectl binary (requires build environment)

🤖 Generated with [Claude Code](https://claude.ai/code)